### PR TITLE
Footer region fix

### DIFF
--- a/templates/system/footer.html.twig
+++ b/templates/system/footer.html.twig
@@ -1,7 +1,7 @@
 <!-- FOOTER -->
 <footer>
-  {% if page.footer %}
-  {{ page.footer }}
+  {% if page.footer_first %}
+  {{ page.footer_first }}
   {% endif %}
 
   <!-- Start footer top row wrapper -->


### PR DESCRIPTION
The footer template file fell behind the new footer region declarations.
Previously we had only a *footer* region.  Now we have a footer_first
and a footer_second region.