### PR TITLE
disable font aggregation to fix font issue on azure

### DIFF
--- a/localgov_theme_croydon.libraries.yml
+++ b/localgov_theme_croydon.libraries.yml
@@ -4,7 +4,7 @@ global:
       https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700,700i:
         type: external
     theme:
-      assets/css/font-face.css: {}
+      assets/css/font-face.css: {preprocess: false}
       assets/css/lib/main.css: {}
   js:
     assets/js/bootstrap.min.js: {}


### PR DESCRIPTION
The custom fonts for the theme were not rendering and this was eventually identified as an aggregation issue - this change disables aggregation on the font-face.css file.