### PR TITLE
Empty sidebar for Guides and Service page

### DIFF
--- a/localgov_theme_croydon.theme
+++ b/localgov_theme_croydon.theme
@@ -4,3 +4,33 @@
  * @file
  * Functions to support theming in the localgov_theme_croydon theme.
  */
+
+/**
+ * Implements hook_preprocess_node() for hook_preprocess_node__localgov_guides_overview().
+ *
+ * - Occupies 8 out of 12 columns in wider displays.
+ */
+function localgov_theme_croydon_preprocess_node__localgov_guides_overview(&$variables) {
+
+  $variables['attributes']['class'][] = 'col-md-8';
+}
+
+/**
+ * Implements hook_preprocess_node() for hook_preprocess_node__localgov_guides_page().
+ *
+ * - Occupies 8 out of 12 columns in wider displays.
+ */
+function localgov_theme_croydon_preprocess_node__localgov_guides_page(&$variables) {
+
+  $variables['attributes']['class'][] = 'col-md-8';
+}
+
+/**
+ * Implements hook_preprocess_node() for hook_preprocess_node__localgov_services_page().
+ *
+ * - Occupies 8 out of 12 columns in wider displays.
+ */
+function localgov_theme_croydon_preprocess_node__localgov_services_page(&$variables) {
+
+  $variables['attributes']['class'][] = 'col-md-8';
+}


### PR DESCRIPTION
The Guides overview, Guides pages, and Service pages content types should occupy
two-thirds of the page width in wider displays.