### PR TITLE
Contact paragraph: Updated field names used in style rules

### DIFF
--- a/assets/scss/lib/partials/_contact.scss
+++ b/assets/scss/lib/partials/_contact.scss
@@ -1,4 +1,4 @@
-.paragraph--type--contact {
+.paragraph--type--localgov-contact {
   background: $gray;
   border-left: 0.3125rem solid $primary;
 
@@ -10,7 +10,7 @@
   }
 
   .contact-opentimes {
-    #field--field_para_contact_office_hours {
+    #field--localgov_contact_office_hours {
       > div {
         &:first-child {
           font-size: $h6-font-size;
@@ -55,31 +55,31 @@
       }
     }
 
-    #field--field_para_contact_email {
+    #field--localgov_contact_email {
       &:before {
         content: $fa-envelope;
       }
     }
 
-    #field--field_para_contact_phone {
+    #field--localgov_contact_phone {
       &:before {
         content: $fa-phone;
       }
     }
 
-    #field--field_para_contact_mobile {
+    #field--localgov_contact_mobile {
       &:before {
         content: $fa-mobile;
       }
     }
 
-    #field--field_para_contact_out_of_hours {
+    #field--localgov_contact_out_of_hours {
       &:before {
         content: $fa-moon;
       }
     }
 
-    #field--field_para_contact_minicom {
+    #field--localgov_contact_minicom {
       &:before {
         content: $fa-keyboard;
       }
@@ -187,7 +187,7 @@
       }
     }
 
-    #field--field_para_contact_other_url {
+    #field--localgov_contact_other_url {
       @include rem(margin-left, 20);
     }
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,8 +132,14 @@ const dev = gulp.series(
   gulp.parallel(browserSyncStart, watchStyle, serve)
 );
 
+/** Generates style without any listeners or browserSync */
+const generate = gulp.series(
+  generateStyle,
+);
+
 // Expose the task by exporting it, this allows you to run it from the commandline
 exports.dev = dev;
+exports.generate = generate;
 
 
 /*

--- a/templates/field/address_plain.html.twig
+++ b/templates/field/address_plain.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * @file
+ * Overridden template for the 'plain' address formatter.
+ *
+ * Displays the complete address in one line.
+ *
+ * Available variables:
+ *   - given_name: Given name.
+ *   - additional_name: Additional name.
+ *   - family_name: Family name.
+ *   - organization: Organization.
+ *   - address_line1: First address line.
+ *   - address_line2: Second address line.
+ *   - postal_code: Postal code.
+ *   - sorting_code: Sorting code.
+ *   - dependent_locality: The dependent locality.
+ *     - dependent_locality.code: Dependent locality code.
+ *     - dependent_locality.name: Dependent locality name.
+ *   - locality: The locality subdivision.
+ *     - locality.code: Locality code.
+ *     - locality.name: Locality name.
+ *   - administrative_area: The administrative area subdivision.
+ *     - administrative_area.code: Administrative area code.
+ *     - administrative_area.name: Administrative area name.
+ *   - country: The country.
+ *     - country.code: Country code.
+ *     - country.name: Country name.
+ *
+ * if a subdivision (dependent_locality, locality, administrative_area) was
+ * entered, the array will always have a code. If it's a predefined subdivision,
+ * it will also have a name. The code is always prefered.
+ *
+ * @ingroup themeable
+ */
+#}
+<p class="address" translate="no">
+  {% if given_name or family_name %}
+    {{ given_name }} {{ family_name }},
+  {% endif %}
+  {% if organization %}
+    {{ organization }},
+  {% endif %}
+  {% if address_line1 %}
+    {{ address_line1 }},
+  {% endif %}
+  {% if address_line2 %}
+    {{ address_line2 }},
+  {% endif %}
+  {% if dependent_locality.code %}
+    {{ dependent_locality.code }},
+  {% endif %}
+  {% if locality.code or postal_code or administrative_area.code %}
+    {{ locality.code }} {{ postal_code }} {{ administrative_area.code }},
+  {% endif %}
+  {{ country.name }}
+</p>

--- a/templates/field/field--paragraph--localgov-contact-heading--localgov-contact.html.twig
+++ b/templates/field/field--paragraph--localgov-contact-heading--localgov-contact.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Field template for the Heading field of the Contact paragraph.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if label_hidden %}
+
+    {% for item in items %}
+      <h2>{{ item.content }}</h2>
+    {% endfor %}
+ 
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/field/field--paragraph--localgov-contact-subheading--localgov-contact.html.twig
+++ b/templates/field/field--paragraph--localgov-contact-subheading--localgov-contact.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Field template for the Subheading field of the Contact paragraph.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if label_hidden %}
+
+    {% for item in items %}
+      <h3>{{ item.content }}</h3>
+    {% endfor %}
+ 
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}


### PR DESCRIPTION
Updated the field names to match what the *LocalGov Contact* paragraph currently uses.

Also, added field templates for Plain Address, Contact heading, and Contact
subheading to match the UX.  These templates have been copied from the existing
"croydon" theme.