### PR TITLE
Bug fix for Guide and Service page content width

### DIFF
--- a/localgov_theme_croydon.theme
+++ b/localgov_theme_croydon.theme
@@ -6,31 +6,31 @@
  */
 
 /**
- * Implements hook_preprocess_node() for hook_preprocess_node__localgov_guides_overview().
+ * Implements hook_preprocess_page() for hook_preprocess_page__localgov_guides_overview().
  *
- * - Occupies 8 out of 12 columns in wider displays.
+ * - Content region always occupies 8 out of 12 columns in wider displays.
  */
-function localgov_theme_croydon_preprocess_node__localgov_guides_overview(&$variables) {
+function localgov_theme_croydon_preprocess_page__localgov_guides_overview(&$variables) {
 
-  $variables['attributes']['class'][] = 'col-md-8';
+  $variables['has_sidebar_second'] = TRUE;
 }
 
 /**
- * Implements hook_preprocess_node() for hook_preprocess_node__localgov_guides_page().
+ * Implements hook_preprocess_page() for hook_preprocess_page__localgov_guides_page().
  *
- * - Occupies 8 out of 12 columns in wider displays.
+ * - Content region always occupies 8 out of 12 columns in wider displays.
  */
-function localgov_theme_croydon_preprocess_node__localgov_guides_page(&$variables) {
+function localgov_theme_croydon_preprocess_page__localgov_guides_page(&$variables) {
 
-  $variables['attributes']['class'][] = 'col-md-8';
+  $variables['has_sidebar_second'] = TRUE;
 }
 
 /**
- * Implements hook_preprocess_node() for hook_preprocess_node__localgov_services_page().
+ * Implements hook_preprocess_page() for hook_preprocess_page__localgov_services_page().
  *
- * - Occupies 8 out of 12 columns in wider displays.
+ * - Content region always occupies 8 out of 12 columns in wider displays.
  */
-function localgov_theme_croydon_preprocess_node__localgov_services_page(&$variables) {
+function localgov_theme_croydon_preprocess_page__localgov_services_page(&$variables) {
 
-  $variables['attributes']['class'][] = 'col-md-8';
+  $variables['has_sidebar_second'] = TRUE;
 }


### PR DESCRIPTION
Guides and Services pages should occupy two-thirds of the page width whether or nor there is a sidebar.  We are achieving this by telling these pages that a right sidebar is always present,

Previously, it was only doing so correctly when a right sidebar was absent.