### PR TITLE
Newroom teaser: Added a News date field.

### DIFF
--- a/templates/paragraph/paragraph--localgov-newsroom-teaser.html.twig
+++ b/templates/paragraph/paragraph--localgov-newsroom-teaser.html.twig
@@ -1,0 +1,52 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a Newsroom teaser paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+
+<div class="news-list col-12 col-md-4 py-4 py-md-0">
+  {{ content.localgov_newsroom_teaser_date }}
+
+  <a href="{{ link }}">{{ content.localgov_newsroom_teaser_image }}</a>
+
+  <h4 class="mt-3">
+    <a href="{{ link }}">{{ content.localgov_newsroom_teaser_title }}</a>
+  </h4>
+
+	<p>{{ content.localgov_newsroom_teaser_summary }}</p>
+</div>


### PR DESCRIPTION
The News date should appear as the first item of the newsroom teaser.