### PR TITLE
A new theme region for the Toggle menu

### DIFF
--- a/localgov_theme_croydon.info.yml
+++ b/localgov_theme_croydon.info.yml
@@ -24,6 +24,7 @@ regions:
   search: "Search"
   primary_menu: "Primary menu"
   secondary_menu: "Secondary menu"
+  toggle_menu: "Toggle menu"
   banner: "Banner"
   breadcrumb: "Breadcrumb"
   messages: "Messages"

--- a/templates/system/header.html.twig
+++ b/templates/system/header.html.twig
@@ -55,11 +55,8 @@
   <nav class="header--expand site-max header--toggle mt-2">
     <div class="row">
       <div class="col-md-12 p-4">
-      {{ page.primary_menu }}
+      {{ page.toggle_menu }}
       </div>
-      <!-- removed for soft launch <div class="col-sm-4 p-4">
-      {{ page.secondary_menu }}
-      </div> -->
     </div>
   </nav>
 </header>


### PR DESCRIPTION
Added a new theme region for the Toggle menu.  This region can have its own menu
block which saves us from displaying the same menu block twice in one page.
Duplicate blocks lead to duplicate Ids in the markup which is invalid.