### PR TITLE
fix directories downloads layout

### DIFF
--- a/templates/field/field--node--localgov-directory-files--localgov-directories-venue.html.twig
+++ b/templates/field/field--node--localgov-directory-files--localgov-directories-venue.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Directory venue field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if label_hidden %}
+
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+ 
+{% else %}
+  <div{{ attributes }}>
+    <h3{{ title_attributes.addClass(title_classes) }}>{{ label }}</h3>
+    {% if multiple %}
+      <ul>
+    {% endif %}
+    {% for item in items %}
+      <li>{{ item.content }}</li>
+    {% endfor %}
+    {% if multiple %}
+      </ul>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/field/file-link.html.twig
+++ b/templates/field/file-link.html.twig
@@ -25,7 +25,7 @@
 <span{{ attributes }}>
   {{ link }}
 
-  <small class="file-meta">
+  <small class="file-meta pl-1">
     {{- '(' -}}
     <span class="file-type">{{ file_type|upper }}</span>,
     <span class="file-size">{{ file_size }}</span>

--- a/templates/field/file-link.html.twig
+++ b/templates/field/file-link.html.twig
@@ -25,10 +25,10 @@
 <span{{ attributes }}>
   {{ link }}
 
-  <span class="file-meta">
+  <small class="file-meta">
     {{- '(' -}}
     <span class="file-type">{{ file_type|upper }}</span>,
     <span class="file-size">{{ file_size }}</span>
     {{- ')' -}}
-  </span>
+  </small>
 </span>

--- a/templates/paragraph/paragraph--localgov-documents--default.html.twig
+++ b/templates/paragraph/paragraph--localgov-documents--default.html.twig
@@ -1,0 +1,67 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a Documents paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ * - documents: array of document data:
+ *   - name (render array for document field)
+ *   - size (document's file size)
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'documents'
+  ]
+%}
+
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {% if documents %}
+      <h3>{{ 'File attachments'|t }}</h3>
+        <ul>
+          {% for document in documents %}
+            <li>{{ document.name }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
This is a change to the layout for the directory file downloads list. It now uses an h3 header, bullet list for the items and a 'small' tag for the file type and size. Also the downloads list appears in a table format on subsites pages - this has also been amended to reflect the correct format.