### PR TITLE
reinstate remove the hide link functionality

### DIFF
--- a/templates/localgov-alert-banner--full.html.twig
+++ b/templates/localgov-alert-banner--full.html.twig
@@ -43,9 +43,11 @@
         {% if content.link %} {{ content.link }} {% endif %}
         </p>
       </div>
+      {% if not remove_hide_link %}
       <div class="col-12 col-sm-2 text-right pt-0 pt-sm-3 pb-3 pl-5 text-nowrap">
         <a href="#" id="closeGlobalBanner" class="js-alert-banner-close">{{ 'Hide' | t }} <span class="sr-only">{{ 'Click here to hide this notification' | t }}</span></a><i class="fas fa-times-circle" aria-hidden="true"></i>
       </div>
+      {% endif %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
@Adnan-cds noticed that the 'remove the hide link' option for banners wasn't working and it was identified that the if statement controlling it had disappeared from the croydon version of the template. I have reinstated this and tested - all works ok.