### PR TITLE
remove a to z link from the nav

### DIFF
--- a/templates/system/header.html.twig
+++ b/templates/system/header.html.twig
@@ -28,9 +28,6 @@
           {{ page.secondary_menu }}
         </li>
         <li class="nav-item">
-          <a class="nav-link px-2 px-lg-3" href="https://www.croydon.gov.uk/atoz">A to Z</a>
-        </li>
-        <li class="nav-item">
           <a class="nav-link px-2 px-lg-3" href="http://maps.croydon.gov.uk/aya/pages/aya/aya.html">In your area</a>
         </li>
         <li class="nav-item">


### PR DESCRIPTION
Removed the A to Z link from the header nav as it is no longer required.