### PR TITLE
Fix for file types

### DIFF
--- a/localgov_theme_croydon.theme
+++ b/localgov_theme_croydon.theme
@@ -58,8 +58,24 @@ function localgov_theme_croydon_preprocess_file_link(&$variables) {
 
   $file = $variables['file'];
   $mime_type = $file->getMimeType();
-  // application/pdf -> pdf
-  $variables['file_type'] = explode('/', $mime_type)[1] ?? '-';
+  // application/pdf -> pdf.
+  $filetype = explode('/', $mime_type)[1] ?? '-';
+
+  switch ($filetype) {
+    case 'vnd.openxmlformats-officedocument.wordprocessingml.document':
+      $filetype = 'Docx';
+      break;
+
+    case 'vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+      $filetype = 'Spreadsheet';
+      break;
+
+    case 'vnd.openxmlformats-officedocument.presentationml.presentation':
+      $filetype = 'Powerpoint';
+      break;
+  }
+
+  $variables['file_type'] = strtoupper($filetype);
 
   // 123.45 KB -> 123.45KB
   $variables['file_size'] = strtr($variables['file_size'], [' ' => '']);

--- a/localgov_theme_croydon.theme
+++ b/localgov_theme_croydon.theme
@@ -67,11 +67,19 @@ function localgov_theme_croydon_preprocess_file_link(&$variables) {
       break;
 
     case 'vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-      $filetype = 'Spreadsheet';
+      $filetype = 'Xlsx';
       break;
 
     case 'vnd.openxmlformats-officedocument.presentationml.presentation':
-      $filetype = 'Powerpoint';
+      $filetype = 'Pptx';
+      break;
+
+    case 'vnd.ms-powerpoint':
+      $filetype = 'ms-powerpoint';
+      break;
+
+    case 'vnd.ms-excel':
+      $filetype = 'ms-excel';
       break;
   }
 


### PR DESCRIPTION
File types are displayed next to filenames (e.g. "foo.pdf (PDF, 123KB)") when Media Documents are rendered.  This wasn't working for several MSOffice file types.  Fixed now.

Fixed mime types:
- vnd.openxmlformats-officedocument.wordprocessingml.document -> Docx.
- vnd.openxmlformats-officedocument.spreadsheetml.sheet -> Spreadsheet.
- vnd.openxmlformats-officedocument.presentationml.presentation -> Powerpoint.

@see https://filext.com/faq/office_mime_types.html