### PR TITLE
Fix for file types: Use extension as file type.

### DIFF
--- a/localgov_theme_croydon.theme
+++ b/localgov_theme_croydon.theme
@@ -49,44 +49,26 @@ function localgov_theme_croydon_preprocess_page__localgov_services_page(&$variab
  * Implements hook_preprocess_file_link().
  *
  * Changes:
- * - Inserts file *type* into the theme variable.
+ * - Inserts file *type* and size into the theme variable.
  * - Reformats file size.  Example: 123.4KB.
+ * - Appends file metadata to the file link text.
  *
  * @see template_preprocess_file_link()
  */
 function localgov_theme_croydon_preprocess_file_link(&$variables) {
 
   $file = $variables['file'];
-  $mime_type = $file->getMimeType();
-  // application/pdf -> pdf.
-  $filetype = explode('/', $mime_type)[1] ?? '-';
+  $filename = $file->getFilename();
+  $file_extension = pathinfo($filename, PATHINFO_EXTENSION);
 
-  switch ($filetype) {
-    case 'vnd.openxmlformats-officedocument.wordprocessingml.document':
-      $filetype = 'Docx';
-      break;
-
-    case 'vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-      $filetype = 'Xlsx';
-      break;
-
-    case 'vnd.openxmlformats-officedocument.presentationml.presentation':
-      $filetype = 'Pptx';
-      break;
-
-    case 'vnd.ms-powerpoint':
-      $filetype = 'ms-powerpoint';
-      break;
-
-    case 'vnd.ms-excel':
-      $filetype = 'ms-excel';
-      break;
-  }
-
-  $variables['file_type'] = strtoupper($filetype);
+  $variables['file_type'] = strtoupper($file_extension);
 
   // 123.45 KB -> 123.45KB
   $variables['file_size'] = strtr($variables['file_size'], [' ' => '']);
+
+  $variables['link']['#title'] = [
+    '#markup' => "{$variables['link']['#title']} <span class=\"file-meta\">(<span class=\"file-type\">{$variables['file_type']}</span>, <span class=\"file-size\">{$variables['file_size']}</span>)</span>",
+  ];
 }
 
 /**

--- a/templates/field/file-link.html.twig
+++ b/templates/field/file-link.html.twig
@@ -24,11 +24,4 @@
 #}
 <span{{ attributes }}>
   {{ link }}
-
-  <small class="file-meta pl-1">
-    {{- '(' -}}
-    <span class="file-type">{{ file_type|upper }}</span>,
-    <span class="file-size">{{ file_size }}</span>
-    {{- ')' -}}
-  </small>
 </span>


### PR DESCRIPTION
File type value equates the file extension rather than the mimetype.

File metadata appears as part of the file link's anchor tag.