### PR TITLE
Hotfix: Call out box without background image

### DIFF
--- a/localgov_theme_croydon.theme
+++ b/localgov_theme_croydon.theme
@@ -79,7 +79,7 @@ function localgov_theme_croydon_preprocess_block__subsitebanner_homepage(&$varia
 function localgov_theme_croydon_preprocess_paragraph(&$variables) {
 
   $paragraph = $variables['paragraph'];
-  if ($paragraph->bundle() === 'localgov_call_out_box') {
+  if ($paragraph->bundle() === 'localgov_call_out_box' && !$paragraph->get('localgov_background_image')->isEmpty()) {
     $fid = $paragraph->get('localgov_background_image')->entity->field_media_image[0]->getValue()['target_id'];
     $file_url = File::load($fid)->getFileUri();
     $variables['background_url'] = ImageStyle::load('cds_original_ratio_768_width')->buildUrl($file_url);


### PR DESCRIPTION
Adding a check for the presence of a background image before trying to use it.