### PR TITLE
remove content block as per ticket instructions

### DIFF
--- a/templates/system/page.html.twig
+++ b/templates/system/page.html.twig
@@ -4,43 +4,6 @@
   {% include '@localgov_theme_croydon/system/header.html.twig' with {'page': page, 'border': true} %}
 {% endblock %}
 
-   {% block content %}
-      {% if page.content_top %}
-      <div class="col-sm-12">
-        {{ page.content_top }}
-      </div>
-      {% endif %}
-
-      {% if has_sidebar_first %}
-        <div id="sidebar-first" class="column sidebar col-md-4">
-          <aside class="section" role="complementary">
-            {{ page.sidebar_first }}
-          </aside>
-        </div>
-      {% endif %}
-
-      <main id="content" role="main"{{ content_attributes.addClass(content_classes) }}>
-        <section class="section">
-          <a id="main-content" tabindex="-1"></a>
-          {{ page.content }}
-        </section>
-      </main>
-
-      {% if has_sidebar_second %}
-        <div id="sidebar-second" class="column sidebar col-md-4">
-          <aside class="section" role="complementary">
-            {{ page.sidebar_second }}
-          </aside>
-        </div>
-      {% endif %}
-
-      {% if page.content_bottom %}
-      <div class="col-sm-12">
-        {{ page.content_bottom }}
-      </div>
-      {% endif %}
-    {% endblock %}
-
 {% block footer %}
   {% include '@localgov_theme_croydon/system/footer.html.twig' with {'page': page, 'border': true} %}
 {% endblock %}


### PR DESCRIPTION
Ticket info: Rollback page.html.twig when localgov theme next has a release (dec 2020)

I made a temporary change to 'page.html.twig' in the croydon theme. The long term fix has gone into the same file in localgov-theme. Once this is tagged for release and the croydon site is pulling in the the new changes from localgov-theme - then the 'content' block in this file should be removed.

Update: I have checked and the modified 'content' block is showing in the local gov theme version of this file so it is no longer required in the croydon duplicate,