### PR TITLE
Twig syntax fix.

### DIFF
--- a/templates/eu-cookie-compliance-popup-info--cookie-settings-block.html.twig
+++ b/templates/eu-cookie-compliance-popup-info--cookie-settings-block.html.twig
@@ -38,7 +38,7 @@
 {% set classes = [
   'eu-cookie-compliance-banner',
   'eu-cookie-compliance-banner-info',
-  ['eu-cookie-compliance-banner--', method|replace('_', '-')]|join,
+  ['eu-cookie-compliance-banner--', method|replace({'_': '-'})]|join,
 ] %}
 
 <div{{ attributes.addClass(classes, 'order-1', 'col-12', 'col-md-8', 'p-0') }}>

--- a/templates/eu-cookie-compliance-popup-info--override.html.twig
+++ b/templates/eu-cookie-compliance-popup-info--override.html.twig
@@ -47,7 +47,7 @@
 {% set classes = [
   'eu-cookie-compliance-banner',
   'eu-cookie-compliance-banner-info',
-  ['eu-cookie-compliance-banner--', method|replace('_', '-')]|join,
+  ['eu-cookie-compliance-banner--', method|replace({'_': '-'})]|join,
 ] %}
 
 <div{{ attributes.addClass(classes, 'cookies-notice') }} role="dialog" aria-label="cookienotice">


### PR DESCRIPTION
The fixed issue affects both Drupal 8 and Drupal 9.  Interestingly, Twig 1.x bundled with Drupal 8 never complained about it.  But Twig 2.x bundled with Drupal 9 is complaining.  Hence the fix.  This applies to both Drupal 8 and Drupal 9.  So safe for immediate deployment to the Drupal 8 site and later to the Drupal 9 site.

@see https://twig.symfony.com/doc/1.x/filters/replace.html
@see https://twig.symfony.com/doc/2.x/filters/replace.html