### PR TITLE
ModernGov template page: Fix for broken logo URL

### DIFF
--- a/templates/system/header.html.twig
+++ b/templates/system/header.html.twig
@@ -5,7 +5,7 @@
   <!-- Navbar content -->
    
       <a class="navbar-brand" href="/" title="Croydon Council homepage">
-        <img class="img-fluid" src="{{ front_page|trim('/') ~ logopath }}" alt="Croydon Council Logo" />
+        <img class="img-fluid" src="{{ logopath }}" alt="Croydon Council Logo" />
       </a>
 
       <div class="my-account d-lg-none">


### PR DESCRIPTION
The logo URL was repeating the hostname due to a recent change in how resource URLs are generated in the ModernGov template page.  So instead of saying "https://example.net/logo/foo.png", it was generating "https://example.nethttps://example.net/logo.foo.png".  Fixed now and deployed to dev2.