### PR TITLE
Updating URL of the "My account" page

### DIFF
--- a/templates/system/footer.html.twig
+++ b/templates/system/footer.html.twig
@@ -95,7 +95,7 @@
         <nav aria-label="Footer Navigation">
           <ul class="d-inline-block d-md-flex flex-wrap flex-md-nowrap list-unstyled mb-0">
             <li class="mr-4 mb-1 mb-sm-0">
-              <a href="https://my.croydon.gov.uk">My Account</a>
+              <a href="{{ localgov_front_page }}myaccountheader">My Account</a>
             </li>
             <li class="mr-4 mb-1 mb-sm-0">
               <a href="https://www.croydon.gov.uk/aboutus">About us</a>

--- a/templates/system/header.html.twig
+++ b/templates/system/header.html.twig
@@ -9,7 +9,7 @@
       </a>
 
       <div class="my-account d-lg-none">
-        <a href="https://my.croydon.gov.uk">My Account</a><i class="fas fa-user ml-2 mr-3" aria-hidden="true"></i>
+        <a href="{{ localgov_front_page }}myaccountheader">My Account</a><i class="fas fa-user ml-2 mr-3" aria-hidden="true"></i>
         <!-- Mobile toggle button -->
         <button id="js-nav-toggle" class="btn navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#mobileToggle" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
           <span class="fa fa-times d-none"></span>
@@ -39,7 +39,7 @@
       </ul>
 
       <div class="d-none d-lg-block my-account">
-        <a href="https://my.croydon.gov.uk">My Account</a><i class="fas fa-user ml-2 mr-3" aria-hidden="true"></i>
+        <a href="{{ localgov_front_page }}myaccountheader">My Account</a><i class="fas fa-user ml-2 mr-3" aria-hidden="true"></i>
       </div>
 
       <div class="search-placement">


### PR DESCRIPTION
Replaced https://my.croydon.gov.uk with /myaccountheader which redirects to https://my.croydon.gov.uk/ at the moment but may change later.